### PR TITLE
perf(ci): add concurrency cancel + dedupe Docker build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,32 +6,31 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-
       - name: Run linting
         run: |
           pip install flake8
           flake8 src/ --max-line-length=120 --ignore=E501,W503 || true
-
       - name: Run tests
         run: |
           python -m pytest tests/ -v --tb=short || echo "No tests yet"
-
       - name: Verify imports
         run: |
           python -c "from src.core import OrchestratorEngine, SelfHealingEngine, PipelineManager, TelemetryCollector, ConfigManager; print('All imports OK')"
@@ -42,23 +41,20 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: false
+          load: true
           tags: ark95x-orchestrator:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
       - name: Test Docker image
         run: |
-          docker build -t ark95x-orchestrator:test .
-          docker run --rm ark95x-orchestrator:test python -c "from src.core import OrchestratorEngine; print('Docker OK')"
+          docker run --rm ark95x-orchestrator:latest python -c "from src.core import OrchestratorEngine; print('Docker OK')"
 
   deploy:
     needs: build
@@ -67,7 +63,6 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v4
-
       - name: Deploy notification
         run: |
           echo "ARK95X Omnikernel Orchestrator v1.0.0"


### PR DESCRIPTION
- Add concurrency group to cancel superseded runs (saves runner minutes)
- Build Docker image once with load:true and reuse for test (removes redundant second docker build)